### PR TITLE
DC-131: Removing HttpVerb dependency and using ExecutionContext

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -16,7 +16,6 @@ object HmrcBuild extends Build {
       scalaVersion := "2.11.7",
       libraryDependencies ++= Seq(
         Compile.play,
-        Compile.httpVerbs,
         Test.scalaTest,
         Test.hmrcTest,
         Test.pegdown
@@ -30,7 +29,6 @@ private object BuildDependencies {
   import _root_.play.core.PlayVersion
 
   object Compile {
-    val httpVerbs = "uk.gov.hmrc" %% "http-verbs" % "3.0.0" % "provided"
     val play = "com.typesafe.play" %% "play"% PlayVersion.current % "provided"
   }
 

--- a/src/main/scala/uk/gov/hmrc/play/scheduling/ExclusiveScheduledJob.scala
+++ b/src/main/scala/uk/gov/hmrc/play/scheduling/ExclusiveScheduledJob.scala
@@ -18,17 +18,14 @@ package uk.gov.hmrc.play.scheduling
 
 import java.util.concurrent.Semaphore
 
-import uk.gov.hmrc.play.http.HeaderCarrier
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
-
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 trait ExclusiveScheduledJob extends ScheduledJob {
 
-  def executeInMutex(implicit hc: HeaderCarrier): Future[this.Result]
+  def executeInMutex(implicit ec: ExecutionContext): Future[this.Result]
 
-  final def execute(implicit hc: HeaderCarrier):Future[Result] =
+  final def execute(implicit ec: ExecutionContext):Future[Result] =
     if (mutex.tryAcquire()) {
       Try(executeInMutex) match {
         case Success(f) => f andThen { case _ => mutex.release() }

--- a/src/main/scala/uk/gov/hmrc/play/scheduling/RunningOfScheduledJobs.scala
+++ b/src/main/scala/uk/gov/hmrc/play/scheduling/RunningOfScheduledJobs.scala
@@ -20,8 +20,6 @@ import akka.actor.{Cancellable, Scheduler}
 import org.apache.commons.lang3.time.StopWatch
 import play.api.libs.concurrent.Akka
 import play.api.{Application, GlobalSettings, Logger}
-import uk.gov.hmrc.play.http.HeaderCarrier
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
@@ -35,7 +33,7 @@ trait RunningOfScheduledJobs extends GlobalSettings {
   override def onStart(app: Application) {
     super.onStart(app)
 
-    implicit val hc = HeaderCarrier()
+    implicit val ec = play.api.libs.concurrent.Execution.defaultContext
 
     Logger.info(s"Scheduling jobs: $scheduledJobs")
     cancellables = scheduledJobs.map { job =>
@@ -44,7 +42,7 @@ trait RunningOfScheduledJobs extends GlobalSettings {
         stopWatch.start()
         Logger.info(s"Executing job ${job.name}")
 
-        job.execute(hc).onComplete {
+        job.execute.onComplete {
           case Success(job.Result(message)) =>
             stopWatch.stop()
             Logger.info(s"Completed job ${job.name} in $stopWatch: $message")

--- a/src/main/scala/uk/gov/hmrc/play/scheduling/ScheduledJob.scala
+++ b/src/main/scala/uk/gov/hmrc/play/scheduling/ScheduledJob.scala
@@ -16,14 +16,12 @@
 
 package uk.gov.hmrc.play.scheduling
 
-import uk.gov.hmrc.play.http.HeaderCarrier
-
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.FiniteDuration
 
 trait ScheduledJob {
   def name: String
-  def execute(implicit hc: HeaderCarrier): Future[Result]
+  def execute(implicit ec: ExecutionContext): Future[Result]
   def isRunning: Future[Boolean]
 
   case class Result(message: String)

--- a/src/test/scala/uk/gov/hmrc/play/scheduling/RunningOfScheduledJobsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/scheduling/RunningOfScheduledJobsSpec.scala
@@ -20,7 +20,6 @@ import akka.actor.{Cancellable, Scheduler}
 import org.scalatest.concurrent.Eventually
 import play.api.Application
 import play.api.test.FakeApplication
-import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.test.{DelayProcessing, UnitSpec}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -67,7 +66,7 @@ class RunningOfScheduledJobsSpec extends UnitSpec with Eventually with DelayProc
       var capturedRunnable: Runnable = _
       override val testScheduledJob = new TestScheduledJob {
         var executed = false
-        override def execute(implicit hc: HeaderCarrier) = {
+        override def execute(implicit ec: ExecutionContext ) = {
           executed = true
           Future.successful(this.Result("done"))
         }
@@ -128,7 +127,7 @@ class RunningOfScheduledJobsSpec extends UnitSpec with Eventually with DelayProc
       override lazy val interval: FiniteDuration = 3.seconds
       def name = "TestScheduledJob"
 
-      def execute(implicit hc: HeaderCarrier) = Future.successful(Result("done"))
+      def execute(implicit ec: ExecutionContext) = Future.successful(Result("done"))
       var isRunning: Future[Boolean] = Future.successful(false)
     }
     val testScheduledJob = new TestScheduledJob


### PR DESCRIPTION
This removes the need for `http-verb` by using an implicit `ExecutionContext` in the method signatures instead of a `HeaderCarier`. That would mean that any library that would depend on this and `http-verb` will not by accident import multiple version of `http-verb` that may cause issue in the future. Also, there is no need for `HeaderCarrier` as nothing gets added into it for logging purposes.
