### PR TITLE
DC-2014: increasing time allowed for tests to complete

### DIFF
--- a/src/test/scala/uk/gov/hmrc/play/scheduling/LockedScheduledJobSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/scheduling/LockedScheduledJobSpec.scala
@@ -75,8 +75,8 @@ class LockedScheduledJobSpec
     "let job run in sequence" in {
       val job = new SimpleJob("job1")
       job.continueExecution()
-      Await.result(job.execute, 1.second).message shouldBe "Job with job1 run and completed with result 1"
-      Await.result(job.execute, 1.second).message shouldBe "Job with job1 run and completed with result 2"
+      Await.result(job.execute, 1.minute).message shouldBe "Job with job1 run and completed with result 1"
+      Await.result(job.execute, 1.minute).message shouldBe "Job with job1 run and completed with result 2"
     }
 
     "not allow job to run in parallel" in {


### PR DESCRIPTION
Currently the build at https://build.tax.service.gov.uk/job/DC/job/play-scheduling/ is failing due to tests timing out.