### PR TITLE
Mark library as deprecated for decommissioning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then run the tests and coverage report:
 
 `sbt clean coverage test coverageReport`
 
-If your build fails due to poor test coverage, *DO NOT* lower the test coverage threshold, instead inspect the generated report located here on your local repo: `/target/scala-2.12/scoverage-report/index.html`
+If your build fails due to poor test coverage, *DO NOT* lower the test coverage threshold, instead inspect the generated report located here on your local repo: `/target/scala-2.12/scoverage-report/index.html`.
 
 Then run the integration tests:
 

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,2 +1,4 @@
 repoVisibility: public_0C3F0CE3E6E6448FAD341E7BFA50FCD333E06A20CFF05FCACE61154DDBBADF71
 description: Helpers for scheduling jobs from Play! on the Tax Platform
+deprecated: true
+end-of-life-date: 2025-04-29


### PR DESCRIPTION
Marking library as deprecated for decommissioning. No dependencies detected.